### PR TITLE
Consistent pointers to static_config.qp_scale_compress_strength

### DIFF
--- a/Source/Lib/Codec/psy_rd.c
+++ b/Source/Lib/Codec/psy_rd.c
@@ -294,7 +294,7 @@ uint64_t get_svt_psy_full_dist(const void* s, uint32_t so, uint32_t sp,
 
 double get_hvs_modulation_factor(double psy_rd, bool is_islice, uint8_t temporal_layer_index) {
     if (is_islice) {
-        return psy_rd * 0.5;
+        return psy_rd * 0.4;
     } else if (temporal_layer_index == 0) {
         return psy_rd * 0.75;
     } else if (temporal_layer_index == 1) {

--- a/Source/Lib/Codec/rc_process.c
+++ b/Source/Lib/Codec/rc_process.c
@@ -869,8 +869,8 @@ static int crf_qindex_calc(PictureControlSet *pcs, RATE_CONTROL *rc, int qindex)
             (ppcs->tpl_group_size < (uint32_t)(2 << pcs->ppcs->hierarchical_levels)))
             weight = MIN(weight + 0.1, 1);
 
-        double qstep_ratio = sqrt(ppcs->r0) * weight * qp_scale_compress_weight[pcs->scs->static_config.qp_scale_compress_strength];
-        if (pcs->scs->static_config.qp_scale_compress_strength) {
+        double qstep_ratio = sqrt(ppcs->r0) * weight * qp_scale_compress_weight[scs->static_config.qp_scale_compress_strength];
+        if (scs->static_config.qp_scale_compress_strength) {
             // clamp qstep_ratio so it doesn't get past the weight value
             qstep_ratio = MIN(weight, qstep_ratio);
         }
@@ -973,7 +973,7 @@ static int cqp_qindex_calc(PictureControlSet *pcs, int qindex) {
     int active_worst_quality = qindex;
     if (pcs->temporal_layer_index == 0) {
         const double qratio_grad = pcs->ppcs->hierarchical_levels <= 4 ? 0.3 : 0.2;
-        const double qstep_ratio = (0.2 + (1.0 - (double)active_worst_quality / MAXQ) * qratio_grad) * qp_scale_compress_weight[pcs->scs->static_config.qp_scale_compress_strength];
+        const double qstep_ratio = (0.2 + (1.0 - (double)active_worst_quality / MAXQ) * qratio_grad) * qp_scale_compress_weight[scs->static_config.qp_scale_compress_strength];
         q = scs->cqp_base_q = svt_av1_get_q_index_from_qstep_ratio(active_worst_quality, qstep_ratio, bit_depth);
     } else if (pcs->ppcs->is_ref && pcs->temporal_layer_index < pcs->ppcs->hierarchical_levels) {
         int this_height = pcs->ppcs->temporal_layer_index + 1;
@@ -2339,8 +2339,8 @@ static int rc_pick_q_and_bounds(PictureControlSet *pcs) {
         const unsigned int r0_weight_idx = !frame_is_intra_only(pcs->ppcs) + !!pcs->ppcs->temporal_layer_index;
         assert(r0_weight_idx <= 2);
         double       weight                  = r0_weight[r0_weight_idx];
-        double qstep_ratio             = sqrt(pcs->ppcs->r0) * weight * qp_scale_compress_weight[pcs->scs->static_config.qp_scale_compress_strength];
-        if (pcs->scs->static_config.qp_scale_compress_strength) {
+        double qstep_ratio             = sqrt(pcs->ppcs->r0) * weight * qp_scale_compress_weight[scs->static_config.qp_scale_compress_strength];
+        if (scs->static_config.qp_scale_compress_strength) {
             // clamp qstep_ratio so it doesn't get past the weight value
             qstep_ratio = MIN(weight, qstep_ratio);
         }


### PR DESCRIPTION
Fixes the inconsistencies in rc_process.c on getting static_config.qp_scale_compress_strength - see comment in https://gitlab.com/AOMediaCodec/SVT-AV1/-/merge_requests/2435 and https://github.com/BlueSwordM/svt-av1-psyex/issues/15