### PR TITLE
Fix `llvm-profdata` not found on Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,13 @@ endif()
 
 if(CMAKE_C_COMPILER_ID MATCHES "Clang" AND SVT_AV1_PGO)
     find_program(LLVM_PROFDATA llvm-profdata)
+    if(NOT LLVM_PROFDATA AND APPLE)
+        find_program(XCRUN xcrun)
+        execute_process(COMMAND ${XCRUN} --find llvm-profdata
+            OUTPUT_VARIABLE LLVM_PROFDATA
+            ERROR_QUIET
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+    endif()
     if(NOT LLVM_PROFDATA)
         message(FATAL_ERROR "llvm-profdata not found.")
     endif()


### PR DESCRIPTION
Fix https://discord.com/channels/992019264959676448/1354404565377880204/1376612027874808008 and https://discord.com/channels/992019264959676448/1354404565377880204/1378599171904245802 .

To give a brief summary:
1. To do almost anything related to programming on Mac, you would need the Xcode command line tools from Apple, which includes clang and llvm. This is sufficent for normal situations and most people would not install any other tools.
2. Xcode command line tools can house multiple different toolchain versions. To avoid confusion between different toolchains, command line tools like `llvm-profdata` are not exposed to PATH. The user can execute the `llvm-profdata` from their selected toolchain using `xcrun llvm-profdata`.
3. This pull request adds support for `xcrun` and `xcrun` would only be used if the user didn't add their own `llvm-profdata` to PATH.