### PR TITLE
fix: low_q_taper message

### DIFF
--- a/Source/App/app_config.c
+++ b/Source/App/app_config.c
@@ -1276,7 +1276,7 @@ ConfigEntry config_entry_variance_boost[] = {
     //Spy-rd
     {SINGLE_INPUT, SPY_RD_TOKEN, "[PSY] Alternative psychovisual rate distortion pathways, default is 0 [0-2]; 1 = full, 2 = partial", set_cfg_generic_token},
     //Low Q Taper
-    {SINGLE_INPUT, LOW_Q_TAPER_TOKEN, "Low q taper. If macroblocks are boosted below q15, taper the effect. Default is 0 (off).]", set_cfg_generic_token},
+    {SINGLE_INPUT, LOW_Q_TAPER_TOKEN, "Low q taper. If macroblocks are boosted below q11, taper the effect. Default is 0 (off).]", set_cfg_generic_token},
     //Sharp-tx
     {SINGLE_INPUT, SHARP_TX_TOKEN, "[PSY] Sharp transform optimization, default is 1; best used in combination with psy-rd [0-1]", set_cfg_generic_token},
     //HBD Mode Decisions


### PR DESCRIPTION
motbob has already modified low_q_taper to be effective at q11 instead of q15. See psy-ex/svt-av1-psy@fc53a43 .

The low_q_taper in the testing branch contains this change to q11, so the message should also be updated.
Thanks!