### PR TITLE
fix: Prevent crash from uninitialized memory in spy-rd logic

### DIFF
--- a/Source/Lib/Codec/common_utils.h
+++ b/Source/Lib/Codec/common_utils.h
@@ -67,7 +67,11 @@ static INLINE PredictionMode get_uv_mode(UvPredictionMode mode) {
 // CFL pred behaviorally maps to a unipred inter mode better than to DC intra mode,
 // so manually account for that case
 static INLINE PredictionMode get_uv_mode_cfl_aware(UvPredictionMode mode) {
-    return mode != UV_CFL_PRED ? get_uv_mode(mode) : NEARESTMV;
+    if (mode >= UV_DC_PRED && mode < UV_INTRA_MODES) {
+        return mode != UV_CFL_PRED ? get_uv_mode(mode) : NEARESTMV;
+    } else {
+        return INTRA_INVALID;
+    }
 }
 
 static INLINE TxType intra_mode_to_tx_type(PredictionMode pred_mode, UvPredictionMode pred_mode_uv,


### PR DESCRIPTION
Fixes #3 
~~This commit implements the changes proposed by Gemini 2.5 Pro described [here](https://aistudio.google.com/app/prompts?state=%7B%22ids%22%3A%5B%221MCsoRWezn7OFAKJSAMD3j_3Oju7vZQrJ%22%5D%2C%22action%22%3A%22open%22%2C%22userId%22%3A%22104936066323850620984%22%2C%22resourceKeys%22%3A%7B%7D%7D), thanks to Exorcist from AV1 weeb edition.~~
I can confirm that it indeed fixes the crash, running svt-av1-psyex compiled with either ASan or UBSan+ASan doesn't crash instantly like how it used to.

Checking UBSan+ASan, the issue seems to be related to the prediction mode
```js
D:/svt-av1-psyex/Source/Lib/Codec\common_utils.h:64:12: runtime error: index -1094795586 out of bounds for type 'const PredictionMode[16]'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior D:/svt-av1-psyex/Source/Lib/Codec\common_utils.h:64:12 
=================================================================
==21372==ERROR: AddressSanitizer: access-violation on unknown address 0x7ff5fd89ac78 (pc 0x7ff7008e399f bp 0x0030e7df4820 sp 0x0030e7df45f0 T52)
    ==21372==The signal is caused by a READ memory access.
        #0 0x7ff7008e399e in get_uv_mode D:\svt-av1-psyex\Source\Lib\Codec\common_utils.h:64
        #1 0x7ff7008ab50f in get_uv_mode_cfl_aware D:\svt-av1-psyex\Source\Lib\Codec\common_utils.h:70
```
