### PR TITLE
fix: low-q-taper result of comparison of constant 1 with expression of type 'bool' is always false

### DIFF
--- a/Source/Lib/Globals/enc_settings.c
+++ b/Source/Lib/Globals/enc_settings.c
@@ -917,10 +917,10 @@ EbErrorType svt_av1_verify_settings(SequenceControlSet *scs) {
         return_error = EB_ErrorBadParameter;
     }
 
-    if (config->low_q_taper > 1) {
-        SVT_ERROR("Instance %u: low-q-taper must be between 0 and 1\n", channel_number + 1);
-        return_error = EB_ErrorBadParameter;
-    }
+    // if (config->low_q_taper > 1) {
+    //     SVT_ERROR("Instance %u: low-q-taper must be between 0 and 1\n", channel_number + 1);
+    //     return_error = EB_ErrorBadParameter;
+    // }
 
     if (config->sharp_tx > 1) {
         SVT_ERROR("Instance %u: sharp-tx must be either 0 and 1\n", channel_number + 1);


### PR DESCRIPTION
```
Source\Lib\Globals\enc_settings.c(920,29): warning: result of comparison of constant 1 with expression of type 'bool' is always false [-Wtautological-constant-compare]
  920 |     if (config->low_q_taper > 1) {
      |         ~~~~~~~~~~~~~~~~~~~ ^ ~
1 warning generated.
```
It's already a bool. Not sure if this is all that's needed though. Should there be some checks for bool elsewhere?