### PR TITLE
fix: correctly map `--hbd-mds 3` to full 8-bit MD

### DIFF
--- a/Source/Lib/Codec/enc_mode_config.c
+++ b/Source/Lib/Codec/enc_mode_config.c
@@ -1835,7 +1835,7 @@ void svt_aom_sig_deriv_multi_processes(SequenceControlSet *scs, PictureParentCon
         pcs->hbd_md = 2;
 
     } else if (pcs->scs->static_config.hbd_mds == 3) {
-        pcs->hbd_md = 3;
+        pcs->hbd_md = 0;
     }
 }
     else


### PR DESCRIPTION
`--hbd-mds 3` currently maps `pcs->hbd_md` to `3` which is (as far as I can tell) undefined, and seems to provide the same output as `--hbd-mds 1` as per default fallback behaviour of the encoder.
This PR remaps it to the [correct internal value for full 8-bit MD](https://github.com/BlueSwordM/svt-av1-psyex/blob/bdab8620efd68cbc985a33778e79e567bff5d821/Source/Lib/Codec/definitions.h#L2116), which is `0`.